### PR TITLE
fix: React Hooks violation, duplicate Toaster, and stale search input

### DIFF
--- a/src/ui/components/DetailPanel.tsx
+++ b/src/ui/components/DetailPanel.tsx
@@ -1,5 +1,5 @@
 import { Link, useNavigate } from 'react-router-dom';
-import { Toaster, toast } from 'react-hot-toast';
+import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import FavoriteIcon from './FavoriteIcon';
 import Button from './Button';
@@ -41,10 +41,11 @@ const TitleWithCopy = ({ label, value, onCopy }: TitleWithCopyProps) => {
 }
 
 const DetailPanel = ({ item, onDataChange }: DetailPanelProps) => {
-  if (!item) return null;
   const navigate = useNavigate();
   const { t } = useTranslation();
-  const [favorite, setFavorite] = useState(!!item.favorite);
+  const [favorite, setFavorite] = useState(!!item?.favorite);
+
+  if (!item) return null;
 
   // Copy using navigator.clipboard
   const handleCopy = (target: string | undefined) => {
@@ -75,27 +76,6 @@ const DetailPanel = ({ item, onDataChange }: DetailPanelProps) => {
 
   return (
     <div>
-      <Toaster
-        position="top-right"
-        toastOptions={{
-          className: '',
-          duration: 5000,
-          removeDelay: 1000,
-          style: {
-            background: '#363636',
-            color: '#fff',
-          },
-
-          success: {
-            duration: 3000,
-            iconTheme: {
-              primary: 'green',
-              secondary: 'black',
-            },
-          },
-        }}
-      />
-
       <div className='flex items-center gap-2'>
         {item.translation_text}
         <FavoriteIcon

--- a/src/ui/components/Header.tsx
+++ b/src/ui/components/Header.tsx
@@ -19,7 +19,7 @@ type SearchCategories = {
 const SEARCH_CATEGORIES_KEY = 'search_categories';
 
 const Header = () => {
-  const { register, handleSubmit } = useForm<FormData>();
+  const { register, handleSubmit, setValue } = useForm<FormData>();
   const navigate = useNavigate();
   const { promptName } = useParams<{ promptName: string }>();
   const { t } = useTranslation();
@@ -30,6 +30,10 @@ const Header = () => {
   });
 
   const [settingsOpen, setSettingsOpen] = useState(false);
+
+  useEffect(() => {
+    setValue('search', promptName ?? '');
+  }, [promptName, setValue]);
 
   useEffect(() => {
     localStorage.setItem(SEARCH_CATEGORIES_KEY, JSON.stringify(searchCategories));
@@ -69,7 +73,6 @@ const Header = () => {
                 type="text"
                 className="text-black px-2"
                 placeholder={t('common.SearchWord')}
-                defaultValue={promptName ? promptName : ''}
               />
               <Button 
                 type="submit"

--- a/src/ui/components/Layout.tsx
+++ b/src/ui/components/Layout.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Toaster } from 'react-hot-toast';
 import Header from './Header';
 
 interface LayoutProps {
@@ -8,6 +9,24 @@ interface LayoutProps {
 const Layout = ({ children }: LayoutProps) => {
   return (
     <>
+      <Toaster
+        position="top-right"
+        toastOptions={{
+          duration: 5000,
+          removeDelay: 1000,
+          style: {
+            background: '#363636',
+            color: '#fff',
+          },
+          success: {
+            duration: 3000,
+            iconTheme: {
+              primary: 'green',
+              secondary: 'black',
+            },
+          },
+        }}
+      />
       <Header />
       <main className="p-4">
         {children}


### PR DESCRIPTION
## Summary

- **DetailPanel**: `useNavigate`・`useTranslation`・`useState` を早期 `return` より前に移動し、React Rules of Hooks 違反を修正。`useState` の初期値を `item?.favorite` に変更し null-safe に対応
- **Layout**: `<Toaster>` を `DetailPanel` からアプリのトップレベル (`Layout`) へ移動。複数の DetailPanel が存在してもトースト通知が重複して描画されなくなった
- **Header**: 検索ボックスが別のキーワードで検索した際に前の値が残り続けるバグを修正。`defaultValue` を削除し、`useEffect` + `setValue` で `promptName` の変化を検知して入力欄を同期するよう変更

## Test plan

- [ ] DetailPanel でお気に入りトグルやコピー操作時にトースト通知が正常に表示される
- [ ] DetailPanel を開いた状態でトースト通知が1つだけ表示される（重複なし）
- [ ] 検索結果画面で別のキーワードを入力して検索すると、ヘッダーの検索ボックスが新しいキーワードに更新される
- [ ] 検索結果から直接別のキーワードのリンクに遷移した際も検索ボックスが更新される

🤖 Generated with [Claude Code](https://claude.com/claude-code)