### PR TITLE
feat: add form validation errors and delete functionality

### DIFF
--- a/src/electron/api.ts
+++ b/src/electron/api.ts
@@ -139,6 +139,17 @@ ipcMain.handle('get-translation-list', (_event, data: { keyword: string, categor
   }
 });
 
+// 削除
+ipcMain.handle('delete-translation', (_event, promptName: string) => {
+  try {
+    const stmt = db.prepare(`DELETE FROM prompt_supporter WHERE prompt_name = ?`);
+    stmt.run(promptName);
+    return { success: true };
+  } catch (err) {
+    return { error: String(err) };
+  }
+});
+
 // 追加・更新
 ipcMain.handle('upsert-translation', (_event, data: {
   promptName: string,

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -35,6 +35,9 @@ contextBridge.exposeInMainWorld('backend', {
         category?: string; // categoryを追加
     }) => ipcRenderer.invoke('upsert-translation', data),
 
+    // 翻訳情報を削除
+    deleteTranslation: (promptName: string) => ipcRenderer.invoke('delete-translation', promptName),
+
     // 外部URLを開く
     openExternalUrl: (url: string) => ipcRenderer.invoke('open-external-url', url),
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -40,6 +40,11 @@
     "Settings": "Settings",
     "LanguageSetting": "Language Setting",
     "Version": "Version",
-    "GitHubRepository": "GitHub Repository"
+    "GitHubRepository": "GitHub Repository",
+    "deleteButton": "Delete",
+    "deleteConfirmTitle": "Confirm Deletion",
+    "deleteConfirmMessage": "Are you sure you want to delete \"{{name}}\"? This action cannot be undone.",
+    "deletedMessage": "Deleted successfully",
+    "promptNameRequired": "promptName is required"
   }
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -40,6 +40,11 @@
     "Settings": "設定",
     "LanguageSetting": "言語設定",
     "Version": "バージョン",
-    "GitHubRepository": "GitHub リポジトリ"
+    "GitHubRepository": "GitHub リポジトリ",
+    "deleteButton": "削除",
+    "deleteConfirmTitle": "削除の確認",
+    "deleteConfirmMessage": "「{{name}}」を削除しますか？この操作は元に戻せません。",
+    "deletedMessage": "削除しました",
+    "promptNameRequired": "promptNameは必須です"
   }
 }

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -23,6 +23,7 @@ declare global {
         copyrights?: string;
         category?: string; // categoryを追加
       }) => Promise<{ success?: boolean; error?: string }>;
+      deleteTranslation: (promptName: string) => Promise<{ success?: boolean; error?: string }>;
       openExternalUrl: (url: string) => Promise<{ success?: boolean; error?: string }>; // 外部URLを開くAPIの型定義を追加
       getAppVersion: () => Promise<string | { error: string }>; // アプリケーションのバージョンを取得するAPIの型定義を追加
     };

--- a/src/ui/components/Button.tsx
+++ b/src/ui/components/Button.tsx
@@ -2,7 +2,7 @@ type ButtonProps = {
   text: string;
   type?: 'button' | 'submit' | 'reset';
   onClick?: () => void;
-  variant?: 'primary' | 'secondary';
+  variant?: 'primary' | 'secondary' | 'danger';
   disabled?: boolean;
 };
 
@@ -17,6 +17,8 @@ const Button = ({
   const styles =
     variant === 'secondary'
       ? "bg-gray-300 text-gray-800 hover:bg-gray-400"
+      : variant === 'danger'
+      ? "bg-red-500 text-white hover:bg-red-600"
       : "bg-blue-500 text-white hover:bg-blue-600";
 
   return (

--- a/src/ui/components/ConfirmModal.tsx
+++ b/src/ui/components/ConfirmModal.tsx
@@ -1,0 +1,33 @@
+import { Dialog, DialogPanel, DialogTitle } from '@headlessui/react';
+import { useTranslation } from 'react-i18next';
+import Button from './Button';
+
+type ConfirmModalProps = {
+  isOpen: boolean;
+  title: string;
+  message: string;
+  onConfirm: () => void;
+  onClose: () => void;
+};
+
+const ConfirmModal = ({ isOpen, title, message, onConfirm, onClose }: ConfirmModalProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <Dialog open={isOpen} onClose={onClose} className="relative z-50">
+      <div className="fixed inset-0 bg-black/40" aria-hidden="true" />
+      <div className="fixed inset-0 flex items-center justify-center p-4">
+        <DialogPanel className="bg-white rounded-lg shadow-xl max-w-sm w-full p-6">
+          <DialogTitle className="text-lg font-bold mb-2">{title}</DialogTitle>
+          <p className="text-gray-700 mb-6">{message}</p>
+          <div className="flex justify-end gap-2">
+            <Button text={t('common.cancelButton')} variant="secondary" onClick={onClose} />
+            <Button text={t('common.deleteButton')} variant="danger" onClick={onConfirm} />
+          </div>
+        </DialogPanel>
+      </div>
+    </Dialog>
+  );
+};
+
+export default ConfirmModal;

--- a/src/ui/pages/Edit.tsx
+++ b/src/ui/pages/Edit.tsx
@@ -2,7 +2,9 @@ import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useParams, useNavigate } from 'react-router-dom';
+import toast from 'react-hot-toast';
 import Button from '../components/Button';
+import ConfirmModal from '../components/ConfirmModal';
 
 type FormData = {
   promptName: string;
@@ -18,9 +20,10 @@ const Edit = () => {
   const { t } = useTranslation();
   const { promptName } = useParams<{ promptName?: string }>();
   const navigate = useNavigate();
-  const { register, handleSubmit, reset, setValue, watch } = useForm<FormData>();
+  const { register, handleSubmit, reset, setValue, watch, formState: { errors } } = useForm<FormData>();
   const selectedCategory = watch('category');
   const [isCopyMode, setIsCopyMode] = useState(false);
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
 
   // 編集時は既存データを取得してフォームにセット
   useEffect(() => {
@@ -64,6 +67,17 @@ const Edit = () => {
     }
   };
 
+  const handleDelete = async () => {
+    if (!promptName) return;
+    const res = await window.backend.deleteTranslation(promptName.trim());
+    if (res.error) {
+      toast.error(res.error);
+    } else {
+      toast.success(t('common.deletedMessage'));
+      navigate('/');
+    }
+  };
+
   const onSubmit = async (data: FormData) => {
     const trimmedPromptName = data.promptName.trim();
     await window.backend.upsertTranslation({
@@ -95,11 +109,14 @@ const Edit = () => {
         <div>
           <label className="block font-semibold">{t('common.promptName')}</label>
           <input
-            {...register('promptName', { required: true })}
+            {...register('promptName', { required: t('common.promptNameRequired') })}
             className="border px-2 py-1 w-full"
             disabled={!!promptName && !isCopyMode}
             placeholder={t('common.enterNewPromptName')}
           />
+          {errors.promptName && (
+            <p className="text-red-500 text-sm mt-1">{errors.promptName.message}</p>
+          )}
         </div>
         <div>
           <label className="block font-semibold">{t('common.TranslationText')} ({t("common.Optional")})</label>
@@ -136,8 +153,24 @@ const Edit = () => {
         <div className="flex gap-2">
           <Button type="submit" text={t('common.saveButton')} variant="primary" />
           <Button type="button" text={t('common.cancelButton')} variant="secondary" onClick={() => navigate(-1)} />
+          {promptName && !isCopyMode && (
+            <Button
+              type="button"
+              text={t('common.deleteButton')}
+              variant="danger"
+              onClick={() => setDeleteModalOpen(true)}
+            />
+          )}
         </div>
       </form>
+
+      <ConfirmModal
+        isOpen={deleteModalOpen}
+        title={t('common.deleteConfirmTitle')}
+        message={t('common.deleteConfirmMessage', { name: promptName })}
+        onConfirm={handleDelete}
+        onClose={() => setDeleteModalOpen(false)}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary

- **バリデーションエラー表示**: `Edit` フォームの `promptName` 未入力時に赤文字のエラーメッセージをフィールド直下に表示。これまで送信ボタンを押しても何も起きない（原因不明）という UX 問題を解消
- **削除機能**: 編集モードの `Edit` ページに削除ボタンを追加。クリックすると確認モーダルが開き、承認後にエントリを削除してホームへ遷移する
- **ConfirmModal コンポーネント**: `@headlessui/react` の `Dialog` を使った汎用確認モーダルを新規作成（将来的に他の削除確認にも流用可能）
- **Button `danger` variant**: 赤背景のボタンスタイルを追加

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/electron/api.ts` | `delete-translation` IPC ハンドラを追加 |
| `src/electron/preload.ts` | `deleteTranslation` を expose に追加 |
| `src/types/globals.d.ts` | `deleteTranslation` の型定義を追加 |
| `src/ui/components/ConfirmModal.tsx` | 新規作成 |
| `src/ui/components/Button.tsx` | `danger` variant を追加 |
| `src/ui/pages/Edit.tsx` | バリデーションエラー表示・削除ボタン・モーダル連携を追加 |
| `src/i18n/locales/ja.json` / `en.json` | 削除・バリデーション関連の翻訳キーを追加 |

## Test plan

- [ ] `promptName` を空のまま保存ボタンを押すと赤文字のエラーメッセージが表示される
- [ ] `promptName` を入力すると赤文字が消える
- [ ] 編集モードで削除ボタンが表示される
- [ ] 新規登録モード・コピーモードでは削除ボタンが表示されない
- [ ] 削除ボタンを押すと確認モーダルが開く
- [ ] モーダルでキャンセルを押すと何も起きずモーダルが閉じる
- [ ] モーダルで削除を押すとエントリが削除されホームへ遷移する
- [ ] 削除後、削除したエントリが検索結果に表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)