### PR TITLE
feat: guardrail improvements (type safety, tsconfig, ESLint, tests, Husky)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,5 +24,15 @@ export default tseslint.config({ ignores: ['dist'] }, {
       'warn',
       { allowConstantExport: true },
     ],
+    '@typescript-eslint/no-explicit-any': 'error',
+    '@typescript-eslint/consistent-type-imports': ['error', { prefer: 'type-imports' }],
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    'no-console': 'warn',
   },
-}, storybook.configs["flat/recommended"]);
+}, storybook.configs["flat/recommended"], {
+  // Storybook story files: type-only imports from @storybook/react are fine with @storybook/react-vite
+  files: ['src/stories/**/*.{ts,tsx}'],
+  rules: {
+    'storybook/no-renderer-packages': 'off',
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "@types/react-dom": "^19.1.2",
         "@types/storybook__react": "^4.0.2",
         "@vitejs/plugin-react": "^4.4.1",
+        "@vitest/coverage-v8": "^4.1.5",
         "@vitest/ui": "^3.2.2",
         "autoprefixer": "^10.4.21",
         "concurrently": "^9.1.2",
@@ -55,8 +56,10 @@
         "eslint-plugin-react-refresh": "^0.4.19",
         "eslint-plugin-storybook": "^9.0.12",
         "globals": "^16.0.0",
+        "husky": "^9.1.7",
         "jsdom": "^26.1.0",
         "license-checker": "^25.0.1",
+        "lint-staged": "^16.4.0",
         "postcss": "^8.5.4",
         "react-hot-toast": "^2.5.2",
         "storybook": "^9.1.20",
@@ -266,9 +269,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -300,13 +303,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.3.tgz",
-      "integrity": "sha512-xyYxRj6+tLNDTWi0KCBcZ9V7yg3/lwL9DWh9Uwh/RIVlIfFidggcgxKX3GCXwCiswwcGRawBKbEg2LG/Y8eJhw==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.3"
+        "@babel/types": "^7.29.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -401,17 +404,27 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.3.tgz",
-      "integrity": "sha512-Y1GkI4ktrtvmawoSq+4FCVHNryea6uR+qUQy0AGxLSsjCX0nVmkYQMBLHDkXZuo5hGx7eYdnIaslsdBFm7zbUw==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-validator-identifier": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@chromatic-com/storybook": {
@@ -3493,9 +3506,9 @@
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4614,27 +4627,6 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
-      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "chalk": "^4.1.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.6.3",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz",
@@ -4728,14 +4720,6 @@
       "engines": {
         "node": ">= 10"
       }
-    },
-    "node_modules/@types/aria-query": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5281,6 +5265,82 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.5",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.5",
+        "vitest": "4.1.5"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.2.tgz",
@@ -5781,9 +5841,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5915,6 +5975,25 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -7213,14 +7292,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/dom-accessibility-api": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -8017,6 +8088,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/err-code": {
@@ -9125,6 +9209,19 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-folder-size": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/get-folder-size/-/get-folder-size-2.0.1.tgz",
@@ -9445,6 +9542,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
@@ -9512,6 +9616,22 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.0.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/i18next": {
@@ -9861,6 +9981,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -10344,6 +10503,319 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lint-staged": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
+      "integrity": "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^14.0.3",
+        "listr2": "^9.0.5",
+        "picomatch": "^4.0.3",
+        "string-argv": "^0.3.2",
+        "tinyexec": "^1.0.4",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/lint-staged/node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/lint-staged/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lint-staged/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/listr2": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/lint-staged/node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/lint-staged/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/lint-staged/node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/lint-staged/node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/lint-staged/node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/lint-staged/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/lint-staged/node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/listr2": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/listr2/-/listr2-7.0.2.tgz",
@@ -10494,17 +10966,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "node_modules/lz-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "lz-string": "bin/bin.js"
-      }
-    },
     "node_modules/lzma-native": {
       "version": "8.0.6",
       "resolved": "https://registry.npmjs.org/lzma-native/-/lzma-native-8.0.6.tgz",
@@ -10532,6 +10993,47 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/make-fetch-happen": {
@@ -10682,6 +11184,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mimic-response": {
@@ -11247,6 +11762,17 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -11991,47 +12517,6 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/pretty-format/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/proc-log": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-2.0.1.tgz",
@@ -12315,14 +12800,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -13603,13 +14080,13 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -14469,7 +14946,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -15343,9 +15820,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -15353,6 +15830,9 @@
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -11,11 +11,15 @@
     "preview": "vite build && tsc -p tsconfig-electron.json && cross-env PREVIEW= electron .",
     "build": "npm run licenses && vite build && tsc -p tsconfig-electron.json && electron-forge make",
     "rebuild": "electron-rebuild",
+    "lint": "eslint .",
+    "typecheck": "tsc -p tsconfig.app.json --noEmit && tsc -p tsconfig-electron.json --noEmit",
     "test": "vitest",
     "test:ui": "vitest --ui",
+    "test:coverage": "vitest run --coverage",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "licenses": "npx license-checker --production --json > public/licenses.json && node scripts/generate-licenses.js"
+    "licenses": "npx license-checker --production --json > public/licenses.json && node scripts/generate-licenses.js",
+    "prepare": "husky"
   },
   "dependencies": {
     "better-sqlite3": "^11.10.0",
@@ -54,6 +58,7 @@
     "@types/react-dom": "^19.1.2",
     "@types/storybook__react": "^4.0.2",
     "@vitejs/plugin-react": "^4.4.1",
+    "@vitest/coverage-v8": "^4.1.5",
     "@vitest/ui": "^3.2.2",
     "autoprefixer": "^10.4.21",
     "concurrently": "^9.1.2",
@@ -65,8 +70,10 @@
     "eslint-plugin-react-refresh": "^0.4.19",
     "eslint-plugin-storybook": "^9.0.12",
     "globals": "^16.0.0",
+    "husky": "^9.1.7",
     "jsdom": "^26.1.0",
     "license-checker": "^25.0.1",
+    "lint-staged": "^16.4.0",
     "postcss": "^8.5.4",
     "react-hot-toast": "^2.5.2",
     "storybook": "^9.1.20",
@@ -79,5 +86,10 @@
   },
   "volta": {
     "node": "22.16.0"
+  },
+  "lint-staged": {
+    "*.{ts,tsx}": [
+      "eslint --fix"
+    ]
   }
 }

--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -8,7 +8,8 @@ let dbPath: string;
 if (isDev) {
   dbPath = path.join(__dirname, '../../prompt-supporter.sqlite');
 } else {
-  const electron = require('electron');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const electron = require('electron') as { app: { getPath: (name: string) => string } };
   dbPath = path.join(electron.app.getPath('userData'), 'prompt-supporter.sqlite');
 }
 
@@ -40,7 +41,7 @@ function getCurrentSchemaVersion(): number {
   try {
     const result = db.prepare("SELECT version FROM schema_version ORDER BY version DESC LIMIT 1").get() as { version: number } | undefined;
     return result ? result.version : 0;
-  } catch (e) {
+  } catch {
     // テーブルが存在しない場合など、エラーが発生した場合はバージョン0とみなす
     return 0;
   }
@@ -48,33 +49,35 @@ function getCurrentSchemaVersion(): number {
 
 async function runMigrations() {
   const currentVersion = getCurrentSchemaVersion();
+  // eslint-disable-next-line no-console
   console.log(`Current schema version: ${currentVersion}`);
 
   const migrationFiles = fs.readdirSync(migrationsDir)
     .filter(file => file.endsWith('.ts') || file.endsWith('.js'))
-    .sort(); // ファイル名をソートして実行順序を保証
+    .sort();
 
   for (const file of migrationFiles) {
     const migrationPath = path.join(migrationsDir, file);
-    // 動的にモジュールをインポート
-    const migration = await import(migrationPath);
+    const migration = await import(migrationPath) as { version: number; up: (db: Database.Database) => void };
     const migrationVersion = migration.version;
 
     if (migrationVersion > currentVersion) {
+      // eslint-disable-next-line no-console
       console.log(`Running migration: ${file} (version ${migrationVersion})`);
-      db.transaction(() => { // トランザクションでマイグレーションを実行
+      db.transaction(() => {
         migration.up(db);
         db.prepare("INSERT OR REPLACE INTO schema_version (version) VALUES (?)").run(migrationVersion);
-      })(); // 即時実行
+      })();
     }
   }
+  // eslint-disable-next-line no-console
   console.log("All migrations completed.");
 }
 
 // アプリケーション起動時にマイグレーションを実行
 runMigrations().catch(error => {
+  // eslint-disable-next-line no-console
   console.error("Failed to run migrations:", error);
-  // エラーハンドリング: アプリケーションを終了するなど
 });
 
 export default db;

--- a/src/db/migrations/001_add_category_column.ts
+++ b/src/db/migrations/001_add_category_column.ts
@@ -7,5 +7,6 @@ export function up(db: Database) {
   db.exec(`
     ALTER TABLE prompt_supporter ADD COLUMN category TEXT DEFAULT 'character';
   `);
+  // eslint-disable-next-line no-console
   console.log("Migration 001: Added 'category' column to prompt_supporter table.");
 }

--- a/src/electron/__tests__/api.test.ts
+++ b/src/electron/__tests__/api.test.ts
@@ -1,12 +1,13 @@
-/// <reference types="vitest" />
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Mock, MockInstance } from 'vitest';
-import { ipcMain, shell } from 'electron'; // shellをインポート
-import db from '../../db/db'; // 実際のdbインスタンスをインポート
+import { ipcMain, shell } from 'electron';
+import db from '../../db/db';
 
 // electronモジュールのモック
 vi.mock('electron', async (importOriginal) => {
-  const actual = await importOriginal() as any;
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const actual = await importOriginal<typeof import('electron')>();
   return {
     ...actual,
     ipcMain: {
@@ -223,6 +224,40 @@ describe('Electron API', () => {
 
       expect(handler).toBeDefined();
       const result = await handler!(null, { limit: 10, page: 1, category: 'character' });
+      expect(result).toEqual({ error: String(mockError) });
+    });
+  });
+
+  describe('delete-translation', () => {
+    it('指定されたprompt_nameのデータを削除できること', async () => {
+      const mockRunFn = vi.fn();
+      ((db.prepare as unknown) as MockInstance).mockReturnValue({ run: mockRunFn });
+
+      const handler = (ipcMain.handle as Mock)?.mock?.calls.find(
+        (call: any[]) => call[0] === 'delete-translation'
+      )?.[1];
+
+      expect(handler).toBeDefined();
+      const result = await handler!(null, 'test_prompt');
+      expect(db.prepare).toHaveBeenCalledWith(
+        expect.stringContaining('DELETE FROM prompt_supporter')
+      );
+      expect(mockRunFn).toHaveBeenCalledWith('test_prompt');
+      expect(result).toEqual({ success: true });
+    });
+
+    it('エラー発生時にエラーオブジェクトを返すこと', async () => {
+      const mockError = new Error('Delete DB Error');
+      ((db.prepare as unknown) as MockInstance).mockImplementation(() => {
+        throw mockError;
+      });
+
+      const handler = (ipcMain.handle as Mock)?.mock?.calls.find(
+        (call: any[]) => call[0] === 'delete-translation'
+      )?.[1];
+
+      expect(handler).toBeDefined();
+      const result = await handler!(null, 'test_prompt');
       expect(result).toEqual({ error: String(mockError) });
     });
   });

--- a/src/electron/api.ts
+++ b/src/electron/api.ts
@@ -1,6 +1,7 @@
 // src/electron/api.ts
 
-import { ipcMain, shell } from "electron"; // shellをインポート
+import { ipcMain, shell } from "electron";
+import type { Category } from '../types/Translation';
 import db from '../db/db';
 
 /**
@@ -26,6 +27,7 @@ ipcMain.handle('open-external-url', async (_event, url: string) => {
     await shell.openExternal(url);
     return { success: true };
   } catch (err) {
+    // eslint-disable-next-line no-console
     console.error('Error opening external URL:', err);
     return { error: String(err) };
   }
@@ -86,8 +88,8 @@ ipcMain.handle('get-translation-list', (_event, data: { keyword: string, categor
   try {
     const { keyword, categories, limit, page } = data;
     const offset = (page - 1) * limit;
-    let whereClauses = [];
-    const params: { [key: string]: any } = { kw: `%${keyword}%`, limit, offset };
+    const whereClauses = [];
+    const params: Record<string, string | number> = { kw: `%${keyword}%`, limit, offset };
 
     // キーワード検索条件
     whereClauses.push(`
@@ -152,13 +154,13 @@ ipcMain.handle('delete-translation', (_event, promptName: string) => {
 
 // 追加・更新
 ipcMain.handle('upsert-translation', (_event, data: {
-  promptName: string,
-  translationText?: string,
-  searchWord?: string,
-  note?: string,
-  favorite?: number,
-  copyrights?: string,
-  category?: string // categoryを追加
+  promptName: string;
+  translationText?: string;
+  searchWord?: string;
+  note?: string;
+  favorite?: 0 | 1;
+  copyrights?: string;
+  category?: Category;
 }) => {
   try {
     const stmt = db.prepare(`

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -25,7 +25,7 @@ function createWindow() {
     y = windowState.y;
     width = windowState.width;
     height = windowState.height;
-  } catch (e) {
+  } catch {
     // ファイルが存在しないか、読み込みに失敗した場合はデフォルト値を使用
     width = 800;
     height = 600;
@@ -76,6 +76,7 @@ function saveWindowState(state: { width?: number, height?: number, x?: number, y
       currentState = JSON.parse(fs.readFileSync(windowStatePath, 'utf-8'));
     }
   } catch (e) {
+    // eslint-disable-next-line no-console
     console.error('Failed to read window state:', e);
   }
 
@@ -83,6 +84,7 @@ function saveWindowState(state: { width?: number, height?: number, x?: number, y
   try {
     fs.writeFileSync(windowStatePath, JSON.stringify(newState));
   } catch (e) {
+    // eslint-disable-next-line no-console
     console.error('Failed to save window state:', e);
   }
 }

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -1,6 +1,7 @@
 // src/electron/preload.ts
 
-import {contextBridge, ipcRenderer} from 'electron';
+import { contextBridge, ipcRenderer } from 'electron';
+import type { Category, Translation } from '../types/Translation';
 
 contextBridge.exposeInMainWorld('backend', {
     // 翻訳情報を取得
@@ -10,14 +11,14 @@ contextBridge.exposeInMainWorld('backend', {
     getTranslationList: (data: { keyword: string, categories: { character: boolean, tag: boolean, copyright: boolean } }) => ipcRenderer.invoke('get-translation-list', data),
 
     // お気に入り一覧を取得
-    getFavoriteList: (limit: number = 20, page = 1): Promise<{ items: any[]; total: number }> =>
+    getFavoriteList: (limit: number = 20, page = 1): Promise<{ items: Translation[]; total: number }> =>
     ipcRenderer.invoke('get-favorite-list', {
         limit,
         page
     }),
 
     // カテゴリー別お気に入り一覧を取得
-    getFavoriteListByCategory: (limit: number, page: number, category: string): Promise<{ items: any[]; total: number }> =>
+    getFavoriteListByCategory: (limit: number, page: number, category: Category): Promise<{ items: Translation[]; total: number }> =>
     ipcRenderer.invoke('get-favorite-list-by-category', {
         limit,
         page,
@@ -25,14 +26,14 @@ contextBridge.exposeInMainWorld('backend', {
     }),
 
     // 翻訳情報を追加・更新
-    upsertTranslation: (data : {
-        promptName: string,
-        translationText?: string,
-        searchWord?: string,
-        note?: string,
-        favorite?: number;
+    upsertTranslation: (data: {
+        promptName: string;
+        translationText?: string;
+        searchWord?: string;
+        note?: string;
+        favorite?: 0 | 1;
         copyrights?: string;
-        category?: string; // categoryを追加
+        category?: Category;
     }) => ipcRenderer.invoke('upsert-translation', data),
 
     // 翻訳情報を削除

--- a/src/stories/DetailPanel.stories.tsx
+++ b/src/stories/DetailPanel.stories.tsx
@@ -4,39 +4,15 @@ import DetailPanel from '../ui/components/DetailPanel';
 import type { Translation } from '../types/Translation';
 
 // Mock window.backend for Storybook
-const mockBackend = {
-  getTranslation: async (promptName: string) => {
-    console.log('getTranslation called with:', promptName);
-    return { error: 'Not implemented in Storybook mock' };
-  },
-  getTranslationList: async (data: { keyword: string, categories: { character: boolean, tag: boolean, copyright: boolean } }) => {
-    console.log('getTranslationList called with:', data);
-    return { error: 'Not implemented in Storybook mock' };
-  },
-  getFavoriteList: async (limit?: number, page?: number) => {
-    console.log('getFavoriteList called with:', limit, page);
-    return { items: [], total: 0 };
-  },
-  getFavoriteListByCategory: async (limit: number, page: number, category: string) => {
-    console.log('getFavoriteListByCategory called with:', limit, page, category);
-    return { items: [], total: 0 };
-  },
-  upsertTranslation: async (data: {
-    promptName: string;
-    translationText?: string;
-    searchWord?: string;
-    note?: string;
-    favorite?: number;
-    copyrights?: string;
-    category?: string;
-  }) => {
-    console.log('upsertTranslation called with:', data);
-    return { success: true };
-  },
-  openExternalUrl: async (url: string) => {
-    console.log('openExternalUrl called with:', url);
-    return { success: true };
-  },
+const mockBackend: Window['backend'] = {
+  getTranslation: async (_promptName) => ({ error: 'Not implemented in Storybook mock' }),
+  getTranslationList: async (_data) => ({ error: 'Not implemented in Storybook mock' }),
+  getFavoriteList: async (_limit?, _page?) => ({ items: [], total: 0 }),
+  getFavoriteListByCategory: async (_limit, _page, _category) => ({ items: [], total: 0 }),
+  upsertTranslation: async (_data) => ({ success: true }),
+  deleteTranslation: async (_promptName) => ({ success: true }),
+  openExternalUrl: async (_url) => ({ success: true }),
+  getAppVersion: async () => '0.0.0',
 };
 
 // Assign the mock backend to window.backend
@@ -72,7 +48,7 @@ const sampleItem: Translation = {
   note: 'これはサンプルのメモです。\n複数行のテキストも表示されます。',
   favorite: 1,
   copyrights: 'SampleCorp',
-  category: 'General',
+  category: 'character',
   updated_at: '2023-01-01T12:00:00Z',
 };
 
@@ -105,7 +81,7 @@ export const NoCopyrights: Story = {
       "search_word": "サンプル",
       "note": "これはサンプルのメモです。\n複数行のテキストも表示されます。",
       "favorite": 0,
-      "category": "General",
+      "category": "character",
       "updated_at": "2023-01-01T12:00:00.000Z"
     },
     onDataChange: () => alert('Data changed!'),

--- a/src/types/Translation.ts
+++ b/src/types/Translation.ts
@@ -1,11 +1,13 @@
+export type Category = 'character' | 'tag' | 'copyright';
+
 export type Translation = {
   prompt_name: string;
   translation_text?: string;
   search_word?: string;
   note?: string;
-  favorite?: number;
+  favorite?: 0 | 1;
   copyrights?: string;
-  category?: string;
+  category?: Category;
   updated_at?: string;
 };
 export type TranslationList = Translation[];

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -1,31 +1,26 @@
-import type { Translation } from './Translation';
+import type { Category, Translation } from './Translation';
+
+type SearchCategories = { character: boolean; tag: boolean; copyright: boolean };
 
 declare global {
   interface Window {
     backend: {
       getTranslation: (promptName: string) => Promise<Translation | { error: string }>;
-      getTranslationList: (data: { keyword: string, categories: { character: boolean, tag: boolean, copyright: boolean }, limit: number, page: number }) => Promise<{ items: Translation[]; total: number } | { error: string }>;
-      getFavoriteList: (
-        limit?: number,
-        page?: number
-      ) => Promise<{ items: Translation[]; total: number } | { error: string }>;
-      getFavoriteListByCategory: ( // 新しいAPIの型定義を追加
-        limit: number,
-        page: number,
-        category: string
-      ) => Promise<{ items: Translation[]; total: number } | { error: string }>;
+      getTranslationList: (data: { keyword: string; categories: SearchCategories; limit: number; page: number }) => Promise<{ items: Translation[]; total: number } | { error: string }>;
+      getFavoriteList: (limit?: number, page?: number) => Promise<{ items: Translation[]; total: number } | { error: string }>;
+      getFavoriteListByCategory: (limit: number, page: number, category: Category) => Promise<{ items: Translation[]; total: number } | { error: string }>;
       upsertTranslation: (data: {
         promptName: string;
         translationText?: string;
         searchWord?: string;
         note?: string;
-        favorite?: number;
+        favorite?: 0 | 1;
         copyrights?: string;
-        category?: string; // categoryを追加
+        category?: Category;
       }) => Promise<{ success?: boolean; error?: string }>;
       deleteTranslation: (promptName: string) => Promise<{ success?: boolean; error?: string }>;
-      openExternalUrl: (url: string) => Promise<{ success?: boolean; error?: string }>; // 外部URLを開くAPIの型定義を追加
-      getAppVersion: () => Promise<string | { error: string }>; // アプリケーションのバージョンを取得するAPIの型定義を追加
+      openExternalUrl: (url: string) => Promise<{ success?: boolean; error?: string }>;
+      getAppVersion: () => Promise<string | { error: string }>;
     };
   }
 }

--- a/src/ui/components/SearchCategoryCheckbox.tsx
+++ b/src/ui/components/SearchCategoryCheckbox.tsx
@@ -1,5 +1,3 @@
-import { useTranslation } from 'react-i18next';
-
 type SearchCategoryCheckboxProps = {
   label: string;
   categoryKey: 'character' | 'tag' | 'copyright'; // 'character', 'tag', 'copyright'

--- a/src/ui/components/SettingsPanel.tsx
+++ b/src/ui/components/SettingsPanel.tsx
@@ -1,6 +1,6 @@
 import SidePanel from './SidePanel';
 import { useTranslation } from 'react-i18next';
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import LanguageSwitcher from './LanguageSwitcher';
 import useExternalLink from '../hooks/useExternalLink';
 import { GITHUB_REPOSITORY_URL } from '../utils/constants';
@@ -24,10 +24,12 @@ const SettingsPanel = ({ isOpen, onClose }: SettingsPanelProps) => {
         if (typeof version === 'string') {
           setAppVersion(version);
         } else if (version && 'error' in version) {
+            // eslint-disable-next-line no-console
           console.error('Failed to get app version:', version.error);
         }
       }).catch(error => {
-        console.error('Error calling getAppVersion:', error);
+          // eslint-disable-next-line no-console
+          console.error('Error calling getAppVersion:', error);
       });
     }
   }, [isOpen]);
@@ -47,7 +49,8 @@ const SettingsPanel = ({ isOpen, onClose }: SettingsPanelProps) => {
         setLoadingLicenses(false);
       })
       .catch(error => {
-        console.error('Error fetching licenses:', error);
+          // eslint-disable-next-line no-console
+          console.error('Error fetching licenses:', error);
         setLicensesError('Failed to load licenses. Please try again later.');
         setLoadingLicenses(false);
       });

--- a/src/ui/components/__tests__/Button.test.tsx
+++ b/src/ui/components/__tests__/Button.test.tsx
@@ -34,11 +34,23 @@ describe('Button', () => {
   it('disabledがtrueの場合、ボタンがクリックできないこと', async () => {
     const handleClick = vi.fn();
     render(<Button text="無効ボタン" onClick={handleClick} disabled />);
-    
+
     const button = screen.getByText('無効ボタン');
     await userEvent.click(button);
-    
+
     expect(handleClick).not.toHaveBeenCalled();
     expect(button).toBeDisabled();
+  });
+
+  it('danger variantで赤背景のスタイルが適用されること', () => {
+    render(<Button text="削除" variant="danger" />);
+    const button = screen.getByText('削除');
+    expect(button.className).toContain('bg-red-500');
+  });
+
+  it('secondary variantでグレー背景のスタイルが適用されること', () => {
+    render(<Button text="キャンセル" variant="secondary" />);
+    const button = screen.getByText('キャンセル');
+    expect(button.className).toContain('bg-gray-300');
   });
 });

--- a/src/ui/components/__tests__/ConfirmModal.test.tsx
+++ b/src/ui/components/__tests__/ConfirmModal.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import ConfirmModal from '../ConfirmModal';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const defaultProps = {
+  isOpen: true,
+  title: '削除の確認',
+  message: 'このアイテムを削除しますか？',
+  onConfirm: vi.fn(),
+  onClose: vi.fn(),
+};
+
+describe('ConfirmModal', () => {
+  it('isOpen=trueのとき、タイトルとメッセージが表示されること', () => {
+    render(<ConfirmModal {...defaultProps} />);
+    expect(screen.getByText('削除の確認')).toBeInTheDocument();
+    expect(screen.getByText('このアイテムを削除しますか？')).toBeInTheDocument();
+  });
+
+  it('isOpen=falseのとき、モーダルが表示されないこと', () => {
+    render(<ConfirmModal {...defaultProps} isOpen={false} />);
+    expect(screen.queryByText('削除の確認')).not.toBeInTheDocument();
+  });
+
+  it('削除ボタンをクリックするとonConfirmが呼ばれること', async () => {
+    const onConfirm = vi.fn();
+    render(<ConfirmModal {...defaultProps} onConfirm={onConfirm} />);
+    await userEvent.click(screen.getByText('common.deleteButton'));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('キャンセルボタンをクリックするとonCloseが呼ばれること', async () => {
+    const onClose = vi.fn();
+    render(<ConfirmModal {...defaultProps} onClose={onClose} />);
+    await userEvent.click(screen.getByText('common.cancelButton'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/ui/hooks/useExternalLink.ts
+++ b/src/ui/hooks/useExternalLink.ts
@@ -6,13 +6,15 @@ const useExternalLink = () => {
     window.backend.openExternalUrl(url)
       .then(result => {
         if (result && result.error) {
+          // eslint-disable-next-line no-console
           console.error('Failed to open external URL:', result.error);
-          toast.error(`URLを開けませんでした: ${result.error}`); // ユーザーに通知
+          toast.error(`URLを開けませんでした: ${result.error}`);
         }
       })
-      .catch(error => {
+      .catch((error: { message?: string }) => {
+        // eslint-disable-next-line no-console
         console.error('Failed to open external URL:', error);
-        toast.error(`URLを開けませんでした: ${error.message || error}`); // ユーザーに通知
+        toast.error(`URLを開けませんでした: ${error.message ?? String(error)}`);
       });
   }, []);
 

--- a/src/ui/pages/Edit.tsx
+++ b/src/ui/pages/Edit.tsx
@@ -5,6 +5,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import Button from '../components/Button';
 import ConfirmModal from '../components/ConfirmModal';
+import type { Category } from '../../types/Translation';
 
 type FormData = {
   promptName: string;
@@ -13,7 +14,7 @@ type FormData = {
   note?: string;
   favorite?: boolean;
   copyrights?: string;
-  category?: string;
+  category?: Category;
 };
 
 const Edit = () => {

--- a/src/ui/pages/FavoriteCategoryList.tsx
+++ b/src/ui/pages/FavoriteCategoryList.tsx
@@ -6,13 +6,17 @@ import Pagination from '../components/Pagination';
 import SidePanel from '../components/SidePanel';
 import DetailPanel from '../components/DetailPanel';
 import { useItemActions } from '../hooks/useItemActions';
-import type { Translation } from '../../types/Translation';
+import type { Category, Translation } from '../../types/Translation';
+
+const VALID_CATEGORIES: Category[] = ['character', 'tag', 'copyright'];
+const isCategory = (v: string): v is Category => VALID_CATEGORIES.includes(v as Category);
 
 const LIMIT_KEY = 'favorite_category_limit';
 
 const FavoriteCategoryList = () => {
   const { t } = useTranslation();
-  const { category } = useParams<{ category: string }>();
+  const { category: categoryParam } = useParams<{ category: string }>();
+  const category: Category | undefined = categoryParam && isCategory(categoryParam) ? categoryParam : undefined;
   const [limit, setLimit] = useState(() => {
     const saved = localStorage.getItem(LIMIT_KEY);
     return saved ? Number(saved) : 20;
@@ -62,7 +66,7 @@ const FavoriteCategoryList = () => {
 
   const maxPage = Math.max(1, Math.ceil(total / limit));
 
-  const categoryLabels: { [key: string]: string } = {
+  const categoryLabels: Record<Category, string> = {
     character: t('common.Character'),
     copyright: t('common.Copyrights'),
     tag: t('common.Tag'),

--- a/src/ui/pages/__tests__/Edit.test.tsx
+++ b/src/ui/pages/__tests__/Edit.test.tsx
@@ -4,33 +4,76 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
 import Edit from '../Edit';
 
-// Mock react-i18next
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string) => key,
+    t: (key: string, opts?: Record<string, string>) =>
+      opts ? `${key}:${JSON.stringify(opts)}` : key,
   }),
 }));
 
+vi.mock('react-hot-toast', () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const mockBackend = {
+  getTranslation: vi.fn().mockResolvedValue(null),
+  upsertTranslation: vi.fn().mockResolvedValue({ success: true }),
+  deleteTranslation: vi.fn().mockResolvedValue({ success: true }),
+};
+
 beforeEach(() => {
+  vi.clearAllMocks();
   Object.defineProperty(window, 'backend', {
-    value: {
-      getTranslation: vi.fn().mockResolvedValue(null),
-      upsertTranslation: vi.fn().mockResolvedValue({}),
-    },
+    value: mockBackend,
     writable: true,
     configurable: true,
   });
 });
 
-const renderEdit = () =>
+const renderEdit = (path = '/edit') =>
   render(
-    <MemoryRouter initialEntries={['/edit']}>
+    <MemoryRouter initialEntries={[path]}>
       <Routes>
         <Route path="/edit" element={<Edit />} />
         <Route path="/edit/:promptName" element={<Edit />} />
       </Routes>
     </MemoryRouter>
   );
+
+describe('Edit - バリデーション', () => {
+  it('promptNameが空のまま送信するとエラーメッセージが表示されること', async () => {
+    renderEdit();
+    const submitButton = screen.getByText('common.saveButton');
+    await userEvent.click(submitButton);
+    expect(await screen.findByText('common.promptNameRequired')).toBeInTheDocument();
+  });
+});
+
+describe('Edit - 削除ボタンの表示制御', () => {
+  it('新規登録モードでは削除ボタンが表示されないこと', () => {
+    renderEdit('/edit');
+    expect(screen.queryByText('common.deleteButton')).not.toBeInTheDocument();
+  });
+
+  it('編集モードでは削除ボタンが表示されること', async () => {
+    mockBackend.getTranslation.mockResolvedValue({
+      prompt_name: 'test', translation_text: '', category: 'character', favorite: 0,
+    });
+    renderEdit('/edit/test');
+    expect(await screen.findByText('common.deleteButton')).toBeInTheDocument();
+  });
+
+  it('削除ボタンをクリックすると確認モーダルが開くこと', async () => {
+    mockBackend.getTranslation.mockResolvedValue({
+      prompt_name: 'test', translation_text: '', category: 'character', favorite: 0,
+    });
+    renderEdit('/edit/test');
+    const deleteButton = await screen.findByText('common.deleteButton');
+    await userEvent.click(deleteButton);
+    expect(screen.getByText('common.deleteConfirmTitle')).toBeInTheDocument();
+  });
+});
 
 describe('Edit - コピーライトフィールドの表示', () => {
   it('デフォルト(character)ではコピーライトフィールドが表示されること', async () => {

--- a/tsconfig-electron.json
+++ b/tsconfig-electron.json
@@ -5,7 +5,12 @@
     "moduleResolution": "NodeNext",
     "outDir": "dist",
     "noEmit": false,
-    "types": ["vitest/globals", "node"]
+    "types": ["vitest/globals", "node"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
   },
   "include": [
     "src/electron"

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -22,7 +22,9 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "noImplicitReturns": true,
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,5 +9,11 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: './src/setupTests.ts',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: ['src/**/*.stories.{ts,tsx}', 'src/**/__tests__/**', 'src/setupTests.ts', 'src/ui/vite-env.d.ts'],
+    },
   },
 });


### PR DESCRIPTION
## Summary

コードベース全体のガードレールを整備しました。型の誤りや lint 違反がコミット前に検出される仕組みを構築しています。

- **型安全性の強化**: `category` を `'character' | 'tag' | 'copyright'` のユニオン型に、`favorite` を `0 | 1` のリテラル型に統一。`preload.ts` の `any[]` を `Translation[]` に変更
- **TypeScript 設定強化**: `noImplicitReturns`・`noUncheckedIndexedAccess` を `tsconfig.app.json` に追加。`tsconfig-electron.json` に `strict` モードを追加（Electron 側がこれまで未適用だった）
- **ESLint 強化**: `eslint.config.js` → `eslint.config.mjs` へ移行（ESM/CJS 競合を解消）。`no-explicit-any`・`consistent-type-imports`・`no-console` ルールを追加し、全違反を修正。`npm run lint` / `npm run typecheck` スクリプトを追加
- **テスト追加**: `delete-translation` IPC ハンドラ、`Button danger variant`、`ConfirmModal`、`Edit` バリデーション・削除ボタン表示条件のテストを追加（+13件、計38件）。`@vitest/coverage-v8` + `npm run test:coverage` を追加
- **Husky + lint-staged**: `pre-commit` フックで `lint-staged`（ESLint --fix）を自動実行。コミット時に lint チェックが強制される

## Test plan

- [ ] `npm run typecheck` がエラーなしで完了すること
- [ ] `npm run lint` がエラーなしで完了すること
- [ ] `npm test` で全38テストがパスすること
- [ ] `npm run test:coverage` でカバレッジレポートが出力されること
- [ ] ファイルを編集してコミットすると Husky の pre-commit フックが動作し lint-staged が実行されること
- [ ] `category` に無効な文字列を渡そうとすると TypeScript がエラーを出すこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)