### PR TITLE
fix: upgrade better-sqlite3 to v12.9.0 for Electron 39.x compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "prompt-supporter",
       "version": "0.7.3",
       "dependencies": {
-        "better-sqlite3": "^11.10.0",
+        "better-sqlite3": "^12.9.0",
         "electron-squirrel-startup": "^1.0.1",
         "i18next": "^25.2.1",
         "react": "^19.1.0",
@@ -6518,14 +6518,17 @@
       }
     },
     "node_modules/better-sqlite3": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
-      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
+      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
       }
     },
     "node_modules/binary-extensions": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "better-sqlite3": "^11.10.0",
+    "better-sqlite3": "^12.9.0",
     "electron-squirrel-startup": "^1.0.1",
     "i18next": "^25.2.1",
     "react": "^19.1.0",


### PR DESCRIPTION
## Summary

- Upgrade `better-sqlite3` from `^11.10.0` to `^12.9.0`
- v11.x has no prebuilt binaries for Electron 39.x and falls back to node-gyp source compilation, which fails with the installed VS2019 Build Tools
- v12.9.0 ships prebuilt binaries for Electron 39.x, so `npm run rebuild` now completes successfully without requiring MSBuild

## Test plan

- [ ] Run `npm install` — installs without errors
- [ ] Run `npm run rebuild` — completes with `✔ Rebuild Complete` (no MSBuild invocation)
- [ ] Run `npm run dev` — app launches without `NODE_MODULE_VERSION` mismatch error

🤖 Generated with [Claude Code](https://claude.com/claude-code)